### PR TITLE
fix(web): wrap useSearchParams in Suspense to resolve build error

### DIFF
--- a/web/src/app/search/page.tsx
+++ b/web/src/app/search/page.tsx
@@ -3,7 +3,9 @@ import { Result } from "@/app/components/result";
 import { Search } from "@/app/components/search";
 import { Title } from "@/app/components/title";
 import { useSearchParams } from "next/navigation";
-export default function SearchPage() {
+import { Suspense } from "react";
+
+function SearchPageContent() {
   const searchParams = useSearchParams();
   const query = decodeURIComponent(searchParams.get("q") || "");
   const rid = decodeURIComponent(searchParams.get("rid") || "");
@@ -23,5 +25,13 @@ export default function SearchPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <SearchPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
close [https://github.com/leptonai/search_with_lepton/issues/98](https://github.com/leptonai/search_with_lepton/issues/98)

### Reason  
The reason is that `useSearchParams()` is not wrapped in the `<Suspense>` component, causing Next.js to fail in properly handling client-side dynamic data.

### Solution  
- Add the `"use client"` directive in `src/app/search/page.tsx` to mark it as a client component.  
- Extract the page logic into a `SearchPageContent` component and wrap it with `<Suspense>`, providing a `fallback` UI.  
- Ensure the code adheres to Prettier formatting rules to avoid formatting errors.  

### Updated Core Code:
```tsx
"use client";
import { useSearchParams } from "next/navigation";
import { Suspense } from "react";

function SearchPageContent() {
  const searchParams = useSearchParams();
  const query = decodeURIComponent(searchParams.get("q") || "");
  const rid = decodeURIComponent(searchParams.get("rid") || "");
  return (/* Original JSX */);
}

export default function SearchPage() {
  return (
    <Suspense fallback={<div>Loading...</div>}>
      <SearchPageContent />
    </Suspense>
  );
}